### PR TITLE
WIP: Simplify SessionAuth, add provider for Session context, refine types

### DIFF
--- a/lib/ts/recipe/session/SessionContextProvider.tsx
+++ b/lib/ts/recipe/session/SessionContextProvider.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from "react";
+import SessionContext from "./SessionContext";
+import GlobalSessionManager from "supertokens-website/lib/build/GlobalSessionManager";
+import { SessionManager } from "supertokens-website/lib/build/SessionManager";
+import { SessionContextType } from "./types";
+import { Optional } from "supertokens-website/lib/build/Optional";
+import { Session } from "supertokens-website/lib/build/Session";
+
+type Props = {
+    sessionManager?: SessionManager;
+}
+
+export const SessionContextProvider: React.FC<Props> = ({ sessionManager = GlobalSessionManager, children }) => {
+    const [context, setContext] = useState<SessionContextType>({
+        doesSessionExist: false,
+    });
+
+    useEffect(() =>
+        sessionManager.subscribe({
+            next: (session: Optional<Session>) => {
+                setContext(session.map<SessionContextType>(s => ({
+                    doesSessionExist: true,
+                    userId: s.getUserId(),
+                    jwtPayload: s.getPayload(),
+                })).getOrElse({ doesSessionExist: false }));
+            },
+        }), [sessionManager]);
+
+    return <SessionContext.Provider value={context}>
+        {children}
+    </SessionContext.Provider>
+}

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -49,8 +49,14 @@ export type SessionUserInput = {
 
 export type SessionConfig = RecipeModuleConfig<unknown, unknown, unknown> & SessionUserInput;
 
-export type SessionContextType = {
-    doesSessionExist: boolean;
+type EmptySessionContext = {
+    doesSessionExist: false;
+}
+
+type NonemptySessionContext = {
+    doesSessionExist: true;
     userId: string;
     jwtPayload: any;
-};
+}
+
+export type SessionContextType = EmptySessionContext | NonemptySessionContext;


### PR DESCRIPTION
### Scope
`SessionAuth` component becomes a consumer of Session context to account for `requireAuth` mechanism.

A provider is now `SessionContextProvider`, which subscribes to `GlobalSessionManager`
from core library.

Session context types are refined to use a discriminated union.

### This depends on https://github.com/dulowski-marek/supertokens-website/pull/1

### Note
Unfortunately I wasn't able to test that, due to some problems with npm linking and less knowledge about the build process.
This presents a general idea of how session updates could be accomplished.

All the responsibility of updating session lies in `supertokens-website` library, which can be used nicely to update cross-tab change mechanisms and similar.